### PR TITLE
fix: history id를 datsource에서 직접 지정하여 오류가 생기지 않도록 수정

### DIFF
--- a/src/main/kotlin/com/sessac/healthcare/data/datasource/impl/FileHistoriesDataSource.kt
+++ b/src/main/kotlin/com/sessac/healthcare/data/datasource/impl/FileHistoriesDataSource.kt
@@ -66,9 +66,8 @@ class FileHistoriesDataSource(
     }
 
     override fun createUserHistory(historyDataModel: HistoryDataModel) {
-        require(historyDataModel.historyId !in historyMap.keys) { "이미 존재하는 아이디입니다" }
         cacheUserHistory = null
-        historyMap[historyDataModel.historyId] = historyDataModel
+        historyMap[historyDataModel.historyId] = historyDataModel.copy(historyId = historyMap.size - 1L)
     }
 
     override fun updateUserHistory(historyDataModel: HistoryDataModel) {


### PR DESCRIPTION
# 📝작업한 내용
historyId는 결국 데이터베이스에서 PK와 같은 경우로 고유성의 조건을 가져야한다.
그러므로 유저ID를 필터링 하여 중복처리를 하는 것은 옳지 않다.
또한 해당 PK를 ViewLayer에서 해결 하는 것은 옳지 않다.

위와 같은 이유로 수정하였습니다.
